### PR TITLE
Display VAT amount and improve mobile charts

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
                         <th>Discount</th>
                         <th>Extra Costs</th>
                         <th>Method</th>
-                        <th>VAT</th>
+                        <th>VAT Amount</th>
                         <th>Profit</th>
                         <th>Final Price</th>
                         <th>Notes</th>
@@ -98,7 +98,7 @@
                         <td id="totalDiscount">0</td>
                         <td id="totalExtra">0</td>
                         <td></td>
-                        <td></td>
+                        <td id="totalVat">0</td>
                         <td id="totalProfit">0</td>
                         <td id="totalPrice">0</td>
                         <td></td>

--- a/style.css
+++ b/style.css
@@ -230,11 +230,20 @@ thead th, tfoot td {
     grid-template-columns: 1fr;
     gap: 20px;
 }
- .chart-box {
+.chart-box {
     background-color: var(--chart-bg);
     padding: 10px;
     border-radius: 6px;
     box-shadow: 0 2px 6px var(--shadow-color);
+}
+
+.chart-box canvas {
+    width: 100% !important;
+    height: auto !important;
+}
+
+.vat-amount {
+    margin-left: 5px;
 }
  .modal {
     display: none;


### PR DESCRIPTION
## Summary
- Show VAT amount per item and in totals table
- Calculate and export VAT amounts in PDF and Excel outputs
- Make charts responsive on mobile devices and polish VAT column styling

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c551031e74832ea10166bb9eca4e50